### PR TITLE
Support flask blueprints and increase code compatibility

### DIFF
--- a/flask_genshi.py
+++ b/flask_genshi.py
@@ -183,9 +183,21 @@ class Genshi(object):
         """A :class:`genshi.template.TemplateLoader` that loads templates
         from the same places as Flask.
 
+        .. versionchanged:: 0.6
+            Removed support for flask modules and enabled support for blueprints
         """
-        path = loader.directory(os.path.join(self.app.root_path, self.app.template_folder))
-        return TemplateLoader(path,
+        path = loader.directory(
+            os.path.join(self.app.root_path, self.app.template_folder or 'templates')
+        )
+        blueprint_paths = {}
+        blueprints = getattr(self.app, 'blueprints', {})
+        for name, blueprint in blueprints.items():
+            blueprint_path = os.path.join(
+                blueprint.root_path, blueprint.template_folder or 'templates'
+            )
+            if os.path.isdir(blueprint_path):
+                blueprint_paths[name] = loader.directory(blueprint_path)
+        return TemplateLoader([path, loader.prefixed(**blueprint_paths)],
                               auto_reload=self.app.debug,
                               callback=self.callback)
 

--- a/flask_genshi.py
+++ b/flask_genshi.py
@@ -274,10 +274,6 @@ def generate_template(template=None, context=None,
         context.setdefault(key, value)
     context.setdefault('filters', filters)
     context.setdefault('tests', current_app.jinja_env.tests)
-    for key, value in filters.items():
-        context.setdefault(key, value)
-    for key, value in current_app.jinja_env.tests.items():
-        context.setdefault('is%s' % key, value)
     current_app.update_template_context(context)
 
     if template is not None:

--- a/tests/flask_genshi_testapp/__init__.py
+++ b/tests/flask_genshi_testapp/__init__.py
@@ -1,8 +1,11 @@
 from flask import Flask
 from flask_genshi import Genshi
 
+from .test_blueprint import test_blueprint
+
 
 def create_app():
     app = Flask(__name__)
-    genshi = Genshi(app)
+    app.register_blueprint(test_blueprint)
+    Genshi(app)
     return app

--- a/tests/flask_genshi_testapp/templates/jinja_tests_and_filters.html
+++ b/tests/flask_genshi_testapp/templates/jinja_tests_and_filters.html
@@ -1,8 +1,5 @@
 <p class="${'even' if tests.even(1) else 'odd'}">
     ${filters.upper('Hello World')}
-  <span class="${'odd' if isodd(0) else 'even'}">
-      ${lower('Hello World')}
-  </span>
     ${filters.truncate('Hello World', 10, leeway=0)} <!--! example of environmentfilter -->
     ${' '.join(filters.map(['Foo', 'Bar'], 'lower'))} <!--! example of contextfilter -->
     ${filters.join(['Foo', 'Bar'])} <!--! example of evalcontextfilter -->

--- a/tests/flask_genshi_testapp/templates/prefix-blueprint-template.txt
+++ b/tests/flask_genshi_testapp/templates/prefix-blueprint-template.txt
@@ -1,0 +1,1 @@
+Hello no-prefix-blueprint $name

--- a/tests/flask_genshi_testapp/test_blueprint/__init__.py
+++ b/tests/flask_genshi_testapp/test_blueprint/__init__.py
@@ -1,0 +1,3 @@
+from flask import Blueprint
+
+test_blueprint = Blueprint('test_blueprint', __name__)

--- a/tests/flask_genshi_testapp/test_blueprint/templates/blueprint-template.txt
+++ b/tests/flask_genshi_testapp/test_blueprint/templates/blueprint-template.txt
@@ -1,0 +1,1 @@
+Hello blueprint $name

--- a/tests/flask_genshi_testapp/test_blueprint/templates/prefix-blueprint-template.txt
+++ b/tests/flask_genshi_testapp/test_blueprint/templates/prefix-blueprint-template.txt
@@ -1,0 +1,1 @@
+Hello blueprint $name

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+from flask_genshi import render_template
+
+
+def test_blueprint_templates(app, context):
+    """Templates can be loaded from blueprint packages"""
+    with app.test_request_context():
+        rendered = render_template("test_blueprint/blueprint-template.txt", context)
+        assert rendered == "Hello blueprint Rudolf\n"
+
+        rendered = render_template("test_blueprint/prefix-blueprint-template.txt", context)
+        assert rendered == "Hello blueprint Rudolf\n"
+
+        rendered = render_template("prefix-blueprint-template.txt", context)
+        assert rendered == "Hello no-prefix-blueprint Rudolf\n"

--- a/tests/test_jinja_tests_and_filters.py
+++ b/tests/test_jinja_tests_and_filters.py
@@ -16,9 +16,6 @@ def test_provides_jinja_tests_and_filters(app):
             <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
             <p class="odd">
                 HELLO WORLD
-              <span class="even">
-                  hello world
-              </span>
                 Hello...
                 foo bar
                 FooBar


### PR DESCRIPTION
Larger flask projects can be modularized, in the past these has been achieved by using flask modules, but they have been deprecated and were replaced by blueprints. The original flask-genshi implementation worked with both, since blueprints were internally present in the `app.modules` property. With this property being deprecated the logic needed to be swapped out to support blueprints. 

Older versions of flask-genshi had hard-coded 'templates' as directory for finding templates. Flask introduced the 'template_folder' parameter for both apps and blueprints. Initially the logic was shifted to make use of these, but here we add 'templates' as fall-back so behavior is consistent with earlier versions if the parameter is unset.

The original author added jinja filters as top-level access somewhere between version 0.5.1 and the latest master on their repository. This caused a naming conflict for builtins commands that have a matching jina filter like `lower`, with the jinja filter overshadowing the builtin. This caused problems especially for functions with different signature between the two like `max`. The jinja filter `max` only accepts a single iterable, while Python built-in `max` supports a variable number of inputs to iterate over.

Tox output: 
[tox_output.txt](https://github.com/mobius-medical/flask-genshi/files/5290653/tox_output.txt)
